### PR TITLE
Fix upstream merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # pychallonge
 
+This repository is no longer maintained. Instead, see https://github.com/ZEDGR/pychallonge.
+
 Pychallonge provides python bindings for the
 [CHALLONGE!](http://challonge.com) [API](http://api.challonge.com/v1).
 


### PR DESCRIPTION
Can't seem to merge from upstream repo...  looks like they're now pointing at @Zedgr's repository (as-of something like 14 months ago... LOL)

    Redirect users to ZEDGR's repository